### PR TITLE
Catch old fn* syntax

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -63,6 +63,8 @@
 (defn- fn-handler [f x]
   (let [prelude (take-while (complement sequential?) x)
         remainder (drop (count prelude) x)
+        remainder (if (vector? (first remainder))
+                    (list remainder) remainder)
         body-handler (fn [x]
                        (cmp/with-lexical-scoping
                          (doseq [arg (first x)]

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -56,3 +56,8 @@
                :yes
                (let 0)))
            2)))))
+
+(deftest catch-old-fn*-syntax
+  (is (= (r/walk-exprs (constantly false) identity
+                       '(fn* tst [x seq]))
+         '(fn* tst ([x seq])))))


### PR DESCRIPTION
There's an [old signature](https://github.com/clojure/clojure/blob/master/src/clj/clojure/core.clj#L29) for fn\* which walk-exprs chokes on.  Not sure whether to file this pull request or a bug on clojure.core to update the usages there.

This patch is probably imperfect as it alters the form being returned, albeit to something with the same effect.

Best regards,
Alex
