### PR TITLE
Do not macroexpand when walking into quoted lists

### DIFF
--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -61,3 +61,8 @@
   (is (= (r/walk-exprs (constantly false) identity
                        '(fn* tst [x seq]))
          '(fn* tst ([x seq])))))
+
+(deftest do-not-macroexpand-quoted-things
+  (is (= '(def p '(fn []))
+         (r/walk-exprs (constantly false) identity
+                       '(def p '(fn []))))))


### PR DESCRIPTION
walk-exprs always macroexpands its current form, even when it's walked into a quoted list.  This patch corrects that behavior.  It's just making a special case.  Making the handler framework more general might be preferable.

Best regards,
Alex
