### PR TITLE
Eagerly walk over remainder of catch clause

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -162,7 +162,7 @@
     (cmp/with-lexical-scoping
       (cmp/register-arg (with-meta var {:tag type}))
       (list* 'catch type var
-        (map f body)))))
+        (doall (map f body))))))
 
 (defn- dot-handler [f x]
   (let [[_ hostexpr mem-or-meth & remainder] x]


### PR DESCRIPTION
Handler fn is called lazily for forms in catch clause. This behavior is inconsistent with other forms and and the evaluation context is lost when handler fn is called.  

``` clojure
(let [syms (atom [])]
  (riddley.walk/walk-exprs symbol?
                           (partial swap! syms conj)
                           '(try foo (catch Exception e bar)))
  @syms)

=> [try foo]
```

After the fix:

``` clojure
(let [syms (atom [])]
  (riddley.walk/walk-exprs symbol?
                           (partial swap! syms conj)
                           '(try foo (catch Exception e bar)))
  @syms)

=> [try foo bar]
```
