### PR TITLE
Handle def with docstring

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -89,10 +89,10 @@
           [(body-handler remainder)])))))
 
 (defn- def-handler [f x]
-  (let [[_ n form] x]
+  (let [[_ n & r] x]
     (cmp/with-lexical-scoping
       (cmp/register-local n '())
-      (list 'def (f n) (f form)))))
+      (list* 'def (f n) (doall (map f r))))))
 
 (defn- let-bindings [f x]
   (->> x

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -83,3 +83,7 @@
           (constantly false)
           identity
           '(def p '(fn []))))))
+
+(deftest handle-def-with-docstring
+  (is (= '(def x "docstring" (. clojure.lang.Numbers (add 1 2)))
+         (r/walk-exprs (constantly false) identity '(def x "docstring" (+ 1 2))))))


### PR DESCRIPTION
Current implementation doesn't handle def's with docstrings correctly.
