### PR TITLE
Walk over instance expression in dot forms

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -168,7 +168,7 @@
 (defn- dot-handler [f x]
   (let [[_ hostexpr mem-or-meth & remainder] x]
     (list* '.
-           hostexpr
+           (f hostexpr)
            (if (walkable? mem-or-meth)
              (list* (first mem-or-meth)
                     (doall (map f (rest mem-or-meth))))

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -87,3 +87,7 @@
 (deftest handle-def-with-docstring
   (is (= '(def x "docstring" (. clojure.lang.Numbers (add 1 2)))
          (r/walk-exprs (constantly false) identity '(def x "docstring" (+ 1 2))))))
+
+(deftest walk-over-instance-expression-in-dot-forms
+  (is (= '(. (. clojure.lang.Numbers (add 1 2)) toString)
+         (r/macroexpand-all '(.toString (+ 1 2))))))


### PR DESCRIPTION
The first operand of dot form can be an instance expression and needs to be walked.
