### PR TITLE
Only walk var forms when the predicate passes

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -198,7 +198,7 @@
              walk-exprs' (partial walk-exprs predicate handler special-form?)
              x' (cond
 
-                  (and (walkable? x) (= 'var (first x)))
+                  (and (walkable? x) (= 'var (first x)) (predicate x))
                   (handler (eval x))
 
                   (and (walkable? x) (= 'quote (first x)))

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -62,10 +62,19 @@
 (deftest test-var-evaluation
   (is (= #{#'riddley.walk-test/foo}
          (let [acc (atom #{})]
-           (r/walk-exprs 
-            (constantly false) 
+           (r/walk-exprs
+            (constantly true)
             #(do (swap! acc conj %) %)
-            '(#'riddley.walk-test/foo))
+            '#'riddley.walk-test/foo)
+           @acc))))
+
+(deftest test-doesnt-walk-var-if-not-requested
+  (is (= #{}
+         (let [acc (atom #{})]
+           (r/walk-exprs
+            (constantly false)
+            #(do (swap! acc conj %) %)
+            '#'riddley.walk-test/foo)
            @acc))))
 
 (deftest catch-old-fn*-syntax


### PR DESCRIPTION
I think this is all we need to fix #12 - needed to update an existing test, but I think this is the right behavior.
