### PR TITLE
Allow walking & not-walking the whole quote form

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -201,9 +201,9 @@
                   (and (walkable? x) (= 'var (first x)))
                   (handler (eval x))
 
-                  (and (walkable? x) (= 'quote (first x)))
-                  (list* 'quote (walk-exprs predicate handler (constantly true) (rest x)))
-                  
+                  (and (walkable? x) (= 'quote (first x)) (not (predicate x)))
+                  x
+
                   (predicate x)
                   (handler x)
 

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -84,6 +84,24 @@
           identity
           '(def p '(fn []))))))
 
+(deftest walk-quotes-if-allowed
+  (is (= #{'(quote (do 1 2 3))}
+         (let [acc (atom #{})]
+           (r/walk-exprs
+            #(and (seq? %) (#{'quote} (first %)))
+            #(do (swap! acc conj %) %)
+            '(quote (do 1 2 3)))
+           @acc))))
+
+(deftest dont-walk-quotes-if-not-allowed
+  (is (= #{}
+         (let [acc (atom #{})]
+           (r/walk-exprs
+            #{'do}
+            #(do (swap! acc conj %) %)
+            '(quote (do 1 2 3)))
+           @acc))))
+
 (deftest handle-def-with-docstring
   (is (= '(def x "docstring" (. clojure.lang.Numbers (add 1 2)))
          (r/walk-exprs (constantly false) identity '(def x "docstring" (+ 1 2))))))


### PR DESCRIPTION
Input needed on this one.

Usually with `riddley.walk/walk-exprs`, I can assume I won't walk an expression unless my predicate allows it. I'm using a set, similar to what [proteus does](https://github.com/ztellman/proteus/blob/8c9be632670e319da0470cf6abe83ccfcbd56701/src/proteus.clj#L25-L30). But in the case of `quote`, I can't avoid walking expressions underneath it. 

Originally I thought could just tack a `(predicate x)` onto the condition in [walk-exprs](https://github.com/ztellman/riddley/blob/fbf70b8013344ef2c45bd616b8bcfb412300a7c5/src/riddley/walk.clj#L204-L205) and add another condition that just returns its argument. 

But there's more: if you want to be able to walk a `quote`d form, say to replace `quote` with `foobar`, it can't currently be done in master (as far as I can tell), and the naïve in the previous paragraph doesn't solve it. This patch does seem to solve it and pass the tests, _but_ I'm pretty sure it breaks the idea of not macroexpanding inside a `quote` form. I'm actually having a bit of a hard time writing a test case showing that, but I think I can visualize why it's wrong. So I think sure this isn't really ready for prime time yet, but wanted to get it out there for input & brainstorming.
