### PR TITLE
Preserve meta for exception local in catch clause

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -161,7 +161,7 @@
   (let [[_ type var & body] x]
     (cmp/with-lexical-scoping
       (when var
-        (cmp/register-arg (with-meta var {:tag type})))
+        (cmp/register-arg (with-meta var (merge (meta var) {:tag type}))))
       (list* 'catch type var
         (doall (map f body))))))
 


### PR DESCRIPTION
I noticed this while using clojure.tools.reader IndexingReader which adds column and line info as metadata.
