### PR TITLE
fix for APersistentVector changes in Clojure 1.8.0

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -174,6 +174,10 @@
              (f mem-or-meth))
            (doall (map f remainder)))))
 
+(def pre-clojure-1-8-0?
+  (let [{:keys [major minor]} *clojure-version*]
+    (or (< major 1) (and (= major 1) (< minor 8)))))
+
 (defn walk-exprs
   "A walk function which only traverses valid Clojure expressions.  The `predicate` describes
    whether the sub-form should be transformed.  If it returns true, `handler` is invoked, and
@@ -222,7 +226,7 @@
                      #(doall (map %1 %2)))
                    walk-exprs' x)
 
-                  (instance? java.util.Map$Entry x)
+                  (and pre-clojure-1-8-0? (instance? java.util.Map$Entry x))
                   (clojure.lang.MapEntry.
                     (walk-exprs' (key x))
                     (walk-exprs' (val x)))


### PR DESCRIPTION
It fixes #18 in my case.

There might be legitimate cases where we receive an `APersistentVector` that should really be treated as a `java.util.Map$Entry`. But on the other hand, `APersistentVector` are not necessarily valid instances of `java.util.Map$Entry` (although they implement this interface).

So not a perfect fix, but better than the current situation.