### PR TITLE
Handle APersistentVectors correctly

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -222,7 +222,12 @@
                      #(doall (map %1 %2)))
                    walk-exprs' x)
 
-                  (instance? java.util.Map$Entry x)
+                  (and
+                    (instance? java.util.Map$Entry x)
+                    ; vectors of length 2
+                    (if (instance? clojure.lang.APersistentVector x)
+                      (= (count x) 2)
+                      true))
                   (clojure.lang.MapEntry.
                     (walk-exprs' (key x))
                     (walk-exprs' (val x)))

--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -224,7 +224,8 @@
 
                   (and
                     (instance? java.util.Map$Entry x)
-                    ; vectors of length 2
+                    ; In Clojure 1.8 all vectors implement Map$Entry but only
+                    ; vectors of length 2 should be treated as MapEntries.
                     (if (instance? clojure.lang.APersistentVector x)
                       (= (count x) 2)
                       true))


### PR DESCRIPTION
Within the Clojure type heirarchy, all APersistentVectors are instances
of Map$Entry. Which is awkward, because they don't respond to the
methods in Map$Entry unless they have length 2. Handle the resulting
special cases.