### PR TITLE
Fix vector traversal in Clojure 1.8

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -222,15 +222,15 @@
                      #(doall (map %1 %2)))
                    walk-exprs' x)
 
-                  (instance? java.util.Map$Entry x)
-                  (clojure.lang.MapEntry.
-                    (walk-exprs' (key x))
-                    (walk-exprs' (val x)))
-
                   (or
                     (set? x)
                     (vector? x))
                   (into (empty x) (map walk-exprs' x))
+
+                  (instance? java.util.Map$Entry x)
+                  (clojure.lang.MapEntry.
+                    (walk-exprs' (key x))
+                    (walk-exprs' (val x)))
 
                   (instance? clojure.lang.IRecord x)
                   x

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -86,6 +86,10 @@
   (is (= (r/macroexpand-all '(bit-and 2 1))
          '(. clojure.lang.Numbers (and 2 1)))))
 
+(deftest vector-expansion
+  (is (= (r/macroexpand-all [])
+         [])))
+
 (deftest do-not-macroexpand-quoted-things
   (is (= '(def p '(fn []))
         (r/walk-exprs


### PR DESCRIPTION
In Clojure 1.7.0:

    (instance? java.util.Map$Entry []) #_=> false

while in 1.8.0-RC1:

    (instance? java.util.Map$Entry []) #_=> true

This change broke the logic of a cond in r.walk/walk-exprs.
This commit fixes it by permuting expressions in the cond.