### PR TITLE
Respect `catch` special shadowed by locals

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -205,20 +205,22 @@
                   (handler x)
 
                   (seq? x)
-                  ((condp = (first x)
-                     'do     do-handler
-                     'def    def-handler
-                     'fn*    fn-handler
-                     'let*   let-handler
-                     'loop*  let-handler
-                     'letfn* let-handler
-                     'case*  case-handler
-                     'catch  catch-handler
-                     'reify* reify-handler
-                     'deftype* deftype-handler
-                     '.      dot-handler
-                     #(doall (map %1 %2)))
-                   walk-exprs' x)
+                  (if (contains? (cmp/locals) (first x))
+                    (doall (map walk-exprs' x))
+                    ((condp = (first x)
+                       'do     do-handler
+                       'def    def-handler
+                       'fn*    fn-handler
+                       'let*   let-handler
+                       'loop*  let-handler
+                       'letfn* let-handler
+                       'case*  case-handler
+                       'catch  catch-handler
+                       'reify* reify-handler
+                       'deftype* deftype-handler
+                       '.      dot-handler
+                       #(doall (map %1 %2)))
+                     walk-exprs' x))
 
                   (instance? java.util.Map$Entry x)
                   (clojure.lang.MapEntry.

--- a/test/riddley/walk_test.clj
+++ b/test/riddley/walk_test.clj
@@ -77,6 +77,18 @@
             '#'riddley.walk-test/foo)
            @acc))))
 
+(deftest try-catch-finally-locals
+  (is (= '(let* [catch inc, finally dec, throw +]
+            (try (throw (catch 100) (finally 200))
+                 (catch Exception e)
+                 (finally nil)))
+
+         (r/walk-exprs (constantly false) identity
+           '(let [catch inc, finally dec, throw +]
+             (try (throw (catch 100) (finally 200))
+                  (catch Exception e)
+                  (finally nil)))))))
+
 (deftest catch-old-fn*-syntax
   (is (= (r/walk-exprs (constantly false) identity
                        '(fn* tst [x seq]))


### PR DESCRIPTION
`walk-exprs` processes `catch` as if it was in the `(try .. (catch ..))` position even if it's shadowed by a local.

Attached a fix and a test case.