### PR TITLE
Add support for ClojureCLR

### DIFF
--- a/src/riddley/Riddley.cs
+++ b/src/riddley/Riddley.cs
@@ -1,0 +1,39 @@
+using System;
+using clojure.lang;
+using clojure.lang.CljCompiler.Ast;
+
+namespace Riddley
+{
+    public static class Util
+    {
+		public static LocalBinding LocalBinding(int num, Symbol sym, Symbol tag, Object form)
+		{
+			return new LocalBinding(num, sym, tag, Compiler.Analyze(new ParserContext(RHC.Expression), form), typeof(Object), false, false, false);
+		}
+
+		public static LocalBinding LocalArgument(int num, Symbol sym, Symbol tag)
+        {
+			return new LocalBinding(num, sym, tag, null, typeof(Object), false, true, false);
+        }
+    }
+
+	public class ObjMethod : clojure.lang.CljCompiler.Ast.ObjMethod
+	{
+		public ObjMethod () : base(new ObjExpr(null), null)
+		{
+			
+		}
+
+		public override bool IsVariadic => throw new NotImplementedException();
+
+		public override int NumParams => throw new NotImplementedException();
+
+		public override int RequiredArity => throw new NotImplementedException();
+
+		public override string MethodName => throw new NotImplementedException();
+
+		public override Type ReturnType => throw new NotImplementedException();
+
+		public override Type[] ArgTypes => throw new NotImplementedException();
+	}
+}

--- a/src/riddley/compiler.clj
+++ b/src/riddley/compiler.clj
@@ -3,23 +3,31 @@
     [clojure.lang
      Var
      Compiler
-     Compiler$ObjMethod
-     Compiler$ObjExpr]
-    [riddley
-     Util]))
+     #?@(:clj [Compiler$ObjMethod
+               Compiler$ObjExpr])]
+     #?(:clj  [riddley Util]
+        :cljr [Riddley Util ObjMethod])))
 
 (defn- stub-method []
-  (proxy [Compiler$ObjMethod] [(Compiler$ObjExpr. nil) nil]))
+  #?(:clj (proxy [Compiler$ObjMethod] [(Compiler$ObjExpr. nil) nil])
+     :cljr (ObjMethod.)))
+
 
 (defn tag-of
   "Returns a symbol representing the tagged class of the symbol, or `nil` if none exists."
   [x]
   (when-let [tag (-> x meta :tag)]
     (let [sym (symbol
-                (if (instance? Class tag)
-                  (.getName ^Class tag)
-                  (name tag)))]
-      (when-not (= 'java.lang.Object sym)
+                #?(:clj (if (instance? Class tag)
+                          (.getName ^Class tag)
+                          (name tag))
+                   :cljr (if (instance? Type tag)
+                          (.FullName ^Type tag)
+                          (name tag))
+                        ))]
+      (when-not (= #?(:clj 'java.lang.Object
+                      :cljr 'System.Object)
+                   sym)
         sym))))
 
 (let [n (atom 0)]
@@ -29,25 +37,38 @@
 (defn locals
   "Returns the local binding map, equivalent to the value of `&env`."
   []
-  (when (.isBound Compiler/LOCAL_ENV)
-    @Compiler/LOCAL_ENV))
+  #?(:clj (when (.isBound Compiler/LOCAL_ENV)
+            @Compiler/LOCAL_ENV)
+     :cljr (when (.isBound Compiler/LocalEnvVar)
+             @Compiler/LocalEnvVar)))
 
 (defmacro with-base-env [& body]
   `(binding [*warn-on-reflection* false]
      (with-bindings (if (locals)
                       {}
-                      {Compiler/LOCAL_ENV {}})
+                      {#?(:clj Compiler/LOCAL_ENV
+                          :cljr clojure.lang.Compiler/LocalEnvVar) {}})
        ~@body)))
 
 (defmacro with-lexical-scoping
   "Defines a lexical scope where new locals may be registered."
   [& body]
-  `(with-bindings {Compiler/LOCAL_ENV (locals)}
+  `(with-bindings {#?(:clj Compiler/LOCAL_ENV
+                      :cljr clojure.lang.Compiler/LocalEnvVar) (locals)}
      ~@body))
 
+#?(:cljr (defn get-method-var []
+           (let [field
+                 (.GetField Compiler
+                            "MethodVar"
+                            (enum-or System.Reflection.BindingFlags/NonPublic
+                                     System.Reflection.BindingFlags/Static))]
+             (.GetValue field Compiler))))
+
 (defmacro with-stub-vars [& body]
-  `(with-bindings {Compiler/CLEAR_SITES nil
-                   Compiler/METHOD (stub-method)}
+  `(with-bindings #?(:clj {Compiler/CLEAR_SITES nil
+                           Compiler/METHOD (stub-method)}
+                     :cljr {(get-method-var) (stub-method)})
      ~@body))
 
 ;; if we don't do this in Java, the checkcasts emitted by Clojure cause an
@@ -56,13 +77,13 @@
   "Registers a locally bound variable `v`, which is being set to form `x`."
   [v x]
   (with-stub-vars
-    (.set ^Var Compiler/LOCAL_ENV
+    (.set ^Var #?(:clj Compiler/LOCAL_ENV :cljr Compiler/LocalEnvVar)
 
       ;; we want to allow metadata on the symbols to persist, so remove old symbols first
       (-> (locals)
         (dissoc v)
         (assoc v (try
-                   (Util/localBinding (local-id) v (tag-of v) x)
+                   (Util/LocalBinding (local-id) v (tag-of v) x)
                    (catch Exception _
                      ::analyze-failure)))))))
 
@@ -70,10 +91,10 @@
   "Registers a function argument `x`."
   [x]
   (with-stub-vars
-    (.set ^Var Compiler/LOCAL_ENV
+    (.set ^Var #?(:clj Compiler/LOCAL_ENV :cljr Compiler/LocalEnvVar)
       (-> (locals)
         (dissoc x)
-        (assoc x (Util/localArgument (local-id) x (tag-of x)))))))
+        (assoc x (Util/LocalArgument (local-id) x (tag-of x)))))))
 
 
 

--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -190,7 +190,7 @@
      (cmp/with-base-env
        (let [x (try
                  (macroexpand x special-form?)
-                 (catch ClassNotFoundException _
+                 (catch #?(:clj ClassNotFoundException :cljr TypeLoadException) _
                    x))
              walk-exprs' (partial walk-exprs predicate handler special-form?)
              x' (cond
@@ -222,10 +222,10 @@
                        #(doall (map %1 %2)))
                      walk-exprs' x))
 
-                  (instance? java.util.Map$Entry x)
-                  (clojure.lang.MapEntry.
-                    (walk-exprs' (key x))
-                    (walk-exprs' (val x)))
+                  #?@(:clj [(instance? java.util.Map$Entry x)
+                            (clojure.lang.MapEntry.
+                              (walk-exprs' (key x))
+                              (walk-exprs' (val x)))])
 
                   (or
                     (set? x)


### PR DESCRIPTION
Adds reader conditionals for ClojureCLR to the Clojure implementation
and a C# support class. Uses implementation details of the ClojureCLR
compiler as of clojure/clojure-clr@57507a55.

All tests passing Mono 5.10.1.16. I am not 100% sure how to handle the C# code needed to make this work, so I dropped it in `src/riddley` for now. Let me know if there's a better way.