### PR TITLE
Fix :java-source-paths

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,5 +10,5 @@
           :include [riddley.walk riddley.compiler]
           :output-dir "doc"}
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0"]]}}
-  :java-source-paths ["src/riddley"]
+  :java-source-paths ["src"]
   :javac-options ["-target" "1.6" "-source" "1.6"])


### PR DESCRIPTION
This patch fixes the problem reported in issue #31 where the riddley JAR would include the source files in the JAR root.

After this change, the JAR contents look like this:

    Archive:  target/riddley-0.2.0.jar
      Length      Date    Time    Name
    ---------  ---------- -----   ----
          229  10-09-2019 20:54   META-INF/MANIFEST.MF
         2740  10-09-2019 20:54   META-INF/maven/riddley/riddley/pom.xml
          606  10-09-2019 20:54   META-INF/leiningen/riddley/riddley/project.clj
         2131  10-09-2019 20:54   META-INF/leiningen/riddley/riddley/README.md
            0  10-09-2019 20:54   META-INF/
            0  10-09-2019 20:54   META-INF/maven/
            0  10-09-2019 20:54   META-INF/maven/riddley/
            0  10-09-2019 20:54   META-INF/maven/riddley/riddley/
          141  10-09-2019 20:54   META-INF/maven/riddley/riddley/pom.properties
            0  10-09-2019 20:54   riddley/
         1040  10-09-2019 20:54   riddley/Util.class
         9757  10-09-2019 20:45   riddley/walk.clj
          495  10-09-2019 20:45   riddley/Util.java
         2098  10-09-2019 20:45   riddley/compiler.clj
    ---------                     -------
        19237                     14 files
