### PR TITLE
Walking form which is trying to rewrite a (var ...) special form errors because walk-exprs runs eval on it.

### DIFF
--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -216,7 +216,8 @@
              walk-exprs' (partial walk-exprs predicate handler special-form?)
              x' (cond
 
-                  (and (seq? x) (= 'var (first x)) (predicate x))
+                  (and (not (contains? special-form? 'var))
+                       (seq? x) (= 'var (first x)) (predicate x))
                   (handler (eval x))
 
                   (and (seq? x) (= 'quote (first x)) (not (predicate x)))


### PR DESCRIPTION
When trying to walk a form where I want to handle the var special form `(var ...)` in order to rewrite it to something else and not have it perform the actual var lookup walk-exprs fails, because even if you pass `'var` into `special-form?` walk-exprs will still run `(eval x)` which will cause errors when walking, since the `(var ...)` form being walked is not compatible with the default behavior of the special form and meant to be rewritten.

To solve this, I modified walk-exprs so when `'var` is passed as a `sepcial-form?` it will also skip running eval on it and calling the handler with it.

This was preventing walking macros that want to handle the var special form in different ways.

As far as I understand, this should make sense with what `special-form?` was intended.