### PR TITLE
Add babashka compatibility

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {riddley.compiler/if-bb clojure.core/if}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,16 @@ jobs:
           lein: latest
       - run: lein do clean, test
 
+  lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          clj-kondo: latest
+      - run: clj-kondo --lint src test
+
   bb:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  jvm:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['8', '11', '21']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          lein: latest
+      - run: lein do clean, test
+
+  bb:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          bb: latest
+      # TODO: remove dev-build override once bb with fixes is released
+      - run: bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --dev-build --dir /tmp
+      - run: /tmp/bb test:bb

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,10 @@
+{:paths ["src"]
+ :tasks
+ {test:bb {:doc "Run bb tests"
+           :extra-paths ["test"]
+           :extra-deps {io.github.cognitect-labs/test-runner
+                        {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
+           :requires ([cognitect.test-runner :as tr])
+           :task (apply tr/-main
+                        "-d" "test"
+                        *command-line-args*)}}}

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,8 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(defn compile-java [_]
+  (b/javac {:basis (b/create-basis)
+            :src-dirs ["src"]
+            :class-dir "target/classes"
+            :javac-opts ["--release" "8"]}))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "target/classes"]
+ :deps/prep-lib {:ensure "target/classes"
+                 :alias :build
+                 :fn build/compile-java}
+ :aliases {:build {:paths ["."]
+                   :deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -11,4 +11,4 @@
           :output-dir "doc"}
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0"]]}}
   :java-source-paths ["src/riddley"]
-  :javac-options ["-target" "1.6" "-source" "1.6"])
+  :javac-options ["-target" "8" "-source" "8"])

--- a/src/riddley/compiler.clj
+++ b/src/riddley/compiler.clj
@@ -1,15 +1,19 @@
-(ns riddley.compiler
-  (:import
-    [clojure.lang
-     Var
-     Compiler
-     Compiler$ObjMethod
-     Compiler$ObjExpr]
-    [riddley
-     Util]))
+(ns riddley.compiler)
 
-(defn- stub-method []
-  (proxy [Compiler$ObjMethod] [(Compiler$ObjExpr. nil) nil]))
+(defmacro if-bb [then else]
+  (if (System/getProperty "babashka.version") then else))
+
+;; JVM-only imports
+(if-bb nil
+  (import '[clojure.lang Var Compiler Compiler$ObjMethod Compiler$ObjExpr]
+          '[riddley Util]))
+
+;; BB-only: dynamic var for tracking locals
+(if-bb (def ^:dynamic *locals* nil) nil)
+
+(if-bb nil
+  (defn- stub-method []
+    (proxy [Compiler$ObjMethod] [(Compiler$ObjExpr. nil) nil])))
 
 (defn tag-of
   "Returns a symbol representing the tagged class of the symbol, or `nil` if none exists."
@@ -22,58 +26,72 @@
       (when-not (= 'java.lang.Object sym)
         sym))))
 
-(let [n (atom 0)]
-  (defn- local-id []
-    (swap! n inc)))
+(if-bb nil
+  (let [n (atom 0)]
+    (defn- local-id []
+      (swap! n inc))))
 
 (defn locals
   "Returns the local binding map, equivalent to the value of `&env`."
   []
-  (when (.isBound Compiler/LOCAL_ENV)
-    @Compiler/LOCAL_ENV))
+  (if-bb
+    *locals*
+    (when (.isBound Compiler/LOCAL_ENV)
+      @Compiler/LOCAL_ENV)))
 
 (defmacro with-base-env [& body]
-  `(binding [*warn-on-reflection* false]
-     (with-bindings (if (locals)
-                      {}
-                      {Compiler/LOCAL_ENV {}})
-       ~@body)))
+  (if-bb
+    `(binding [*warn-on-reflection* false]
+       (if *locals*
+         (do ~@body)
+         (binding [*locals* {}]
+           ~@body)))
+    `(binding [*warn-on-reflection* false]
+       (with-bindings (if (locals)
+                        {}
+                        {Compiler/LOCAL_ENV {}})
+         ~@body))))
 
 (defmacro with-lexical-scoping
   "Defines a lexical scope where new locals may be registered."
   [& body]
-  `(with-bindings {Compiler/LOCAL_ENV (locals)}
-     ~@body))
+  (if-bb
+    `(binding [*locals* (or *locals* {})]
+       ~@body)
+    `(with-bindings {Compiler/LOCAL_ENV (locals)}
+       ~@body)))
 
-(defmacro with-stub-vars [& body]
-  `(with-bindings {Compiler/CLEAR_SITES nil
-                   Compiler/METHOD (stub-method)}
-     ~@body))
+(if-bb nil
+  (defmacro with-stub-vars [& body]
+    `(with-bindings {Compiler/CLEAR_SITES nil
+                     Compiler/METHOD (stub-method)}
+       ~@body)))
 
 ;; if we don't do this in Java, the checkcasts emitted by Clojure cause an
 ;; IllegalAccessError on Compiler$Expr.  Whee.
 (defn register-local
   "Registers a locally bound variable `v`, which is being set to form `x`."
   [v x]
-  (with-stub-vars
-    (.set ^Var Compiler/LOCAL_ENV
+  (if-bb
+    (set! *locals* (-> *locals* (dissoc v) (assoc v x)))
+    (with-stub-vars
+      (.set ^clojure.lang.Var Compiler/LOCAL_ENV
 
-      ;; we want to allow metadata on the symbols to persist, so remove old symbols first
-      (-> (locals)
-        (dissoc v)
-        (assoc v (try
-                   (Util/localBinding (local-id) v (tag-of v) x)
-                   (catch Exception _
-                     ::analyze-failure)))))))
+        ;; we want to allow metadata on the symbols to persist, so remove old symbols first
+        (-> (locals)
+          (dissoc v)
+          (assoc v (try
+                     (riddley.Util/localBinding (local-id) v (tag-of v) x)
+                     (catch Exception _
+                       ::analyze-failure))))))))
 
 (defn register-arg
   "Registers a function argument `x`."
   [x]
-  (with-stub-vars
-    (.set ^Var Compiler/LOCAL_ENV
-      (-> (locals)
-        (dissoc x)
-        (assoc x (Util/localArgument (local-id) x (tag-of x)))))))
-
-
-
+  (if-bb
+    (set! *locals* (-> *locals* (dissoc x) (assoc x nil)))
+    (with-stub-vars
+      (.set ^clojure.lang.Var Compiler/LOCAL_ENV
+        (-> (locals)
+          (dissoc x)
+          (assoc x (riddley.Util/localArgument (local-id) x (tag-of x))))))))

--- a/src/riddley/compiler.clj
+++ b/src/riddley/compiler.clj
@@ -1,7 +1,9 @@
 (ns riddley.compiler)
 
+(def ^:private bb? (System/getProperty "babashka.version"))
+
 (defmacro if-bb [then else]
-  (if (System/getProperty "babashka.version") then else))
+  (if bb? then else))
 
 ;; JVM-only imports
 (if-bb nil

--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -21,7 +21,7 @@
              ;; might look like a macro, but for our purposes it isn't
              x
 
-             (let [x' (macroexpand-1 x)]
+             (let [x' (cmp/if-bb (macroexpand-1 (or (cmp/locals) {}) x) (macroexpand-1 x))]
                (if-not (identical? x x')
                  (macroexpand x' special-form?)
 
@@ -102,7 +102,7 @@
 (defn- let-bindings [f x recursive?]
   (let [pairs (partition-all 2 x)]
     (when recursive?
-      (doall (map (fn [[k v]] (cmp/register-local k nil)) pairs)))
+      (doall (map (fn [[k _]] (cmp/register-local k nil)) pairs)))
     (->> pairs
          (mapcat
            (fn [[k v]]

--- a/src/riddley/walk.clj
+++ b/src/riddley/walk.clj
@@ -21,7 +21,7 @@
              ;; might look like a macro, but for our purposes it isn't
              x
 
-             (let [x' (cmp/if-bb (macroexpand-1 (or (cmp/locals) {}) x) (macroexpand-1 x))]
+             (let [x' (cmp/if-bb #_:clj-kondo/ignore (macroexpand-1 (or (cmp/locals) {}) x) (macroexpand-1 x))]
                (if-not (identical? x x')
                  (macroexpand x' special-form?)
 


### PR DESCRIPTION
- Add `if-bb` macro for conditional compilation based on babashka runtime
- Add `*locals*` dynamic var as bb alternative to `Compiler/LOCAL_ENV`
- Implement bb paths in `locals`, `with-base-env`, `with-lexical-scoping`, `register-local`, `register-arg`
- Pass locals as env to `macroexpand-1` in bb, so SCI knows about riddley's tracked locals during macro expansion
- Add deps.edn with prep-lib for Java compilation
- Add bb.edn for running tests with babashka
- Add GitHub Actions CI for JVM (Java 8, 11, 21) and bb tests